### PR TITLE
Make environment variables override local settings even when false

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for NewFangle::Agent
 
 {{$NEXT}}
 
+    * Fixed an issue where environment variables would only be read into
+      the local config if they were truthy. This has been changed so they
+      are read if they are defined.
+
 0.006     2022-03-14 13:57:11 GMT
 
     * Refactored segment starters into packages under the

--- a/lib/NewFangle/Agent/Config.pm
+++ b/lib/NewFangle/Agent/Config.pm
@@ -139,7 +139,7 @@ sub local_settings {
 
     # Merge with environment variables
     while ( my ( $k, $v ) = each %environment ) {
-        $local->{$v} = $ENV{$k} if $ENV{$k};
+        $local->{$v} = $ENV{$k} if defined $ENV{$k};
     }
 
     $local->$set_log;

--- a/t/config.t
+++ b/t/config.t
@@ -57,11 +57,23 @@ subtest 'New Relic environment override' => sub {
 };
 
 subtest 'Environment variables override local config' => sub {
-    my $global = NewFangle::Agent::Config->global_settings;
-    local $ENV{NEWRELIC_ENABLED} = $global->{enabled} ? 1 : 0;
+    my $global  = NewFangle::Agent::Config->global_settings;
+    my $enabled = $global->{enabled} ? 1 : 0;
+
     is +NewFangle::Agent::Config->local_settings,
-        { %$global, enabled => $global->{enabled} ? 1 : 0 },
-        'Can change local settings same as global';
+        { %$global, enabled => $enabled }, 'Initial state';
+
+    # Flip once
+    local $ENV{NEWRELIC_ENABLED} = $enabled = $enabled ? 0 : 1;
+
+    is +NewFangle::Agent::Config->local_settings,
+        { %$global, enabled => $enabled }, 'State changed';
+
+    # Flip back
+    $ENV{NEWRELIC_ENABLED} = $enabled = $enabled ? 0 : 1;
+
+    is +NewFangle::Agent::Config->local_settings,
+        { %$global, enabled => $enabled }, 'State changed back';
 };
 
 done_testing;


### PR DESCRIPTION
Due to faulty logic, environment variables only overrode local settings when they were true, rather than whenever they were defined. This fixes this, and verifies this with `t/config.t`.

When updating `t/config.t`, the scope of each test was reduced, to make it easier to see what each case was testing.