### PR TITLE
Override global config with Defined environment variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for NewFangle::Agent
 
 {{$NEXT}}
+    * Fixed an issue where environment variables would only be read into
+      the global config if they were truthy. This has been changed so they
+      are read if they are defined. This is similar to the issue fixed in
+      0.007.
 
 0.009     2022-08-22 15:46:53 BST
 

--- a/bin/newrelic-admin
+++ b/bin/newrelic-admin
@@ -77,14 +77,17 @@ USAGE
     require NewFangle::Agent;
     require NewFangle::Agent::Config;
 
-    my $cfg = NewFangle::Agent::Config->local_settings;
+    my $config = NewFangle::Agent::Config->local_settings;
+    my $struct = NewFangle::Agent::Config->struct;
 
-    NewFangle::newrelic_configure_log( @$cfg{qw( log_filename log_level )} );
-    NewFangle::newrelic_init( $ENV{NEWRELIC_DAEMON_HOST}, 100 );
+    # C Struct log levels are narrower
+    NewFangle::newrelic_configure_log(
+        @{ $struct->to_perl }{qw( log_filename log_level )}
+    );
 
-    my $app = eval {
-        NewFangle::App->new( NewFangle::Agent::Config->struct, 100 )
-    };
+    NewFangle::newrelic_init( $config->{daemon_host}, 100 );
+
+    my $app = eval { NewFangle::App->new( $struct, 100 ) };
 
     local $NewFangle::Agent::TX;
     $NewFangle::Agent::TX = $app->start_non_web_transaction($txn)

--- a/lib/NewFangle/Agent/Config.pm
+++ b/lib/NewFangle/Agent/Config.pm
@@ -67,7 +67,7 @@ my %environment = (
 
 my $set_log = sub {
     for ( $_[0]->{log_level} ) {
-        my $name = lc;
+        my $name = lc ( $_ // '' );
 
            if ( $name eq 'critical' ) { $_ = dualvar( 0 => $name ) }
         elsif ( $name eq 'error'    ) { $_ = dualvar( 1 => $name ) }
@@ -76,7 +76,7 @@ my $set_log = sub {
         elsif ( $name eq 'debug'    ) { $_ = dualvar( 4 => $name ) }
         elsif ( $name eq 'trace'    ) { $_ = dualvar( 5 => $name ) }
         else {
-            warn "Unrecognised log level in config: $_";
+            warn "Unrecognised log level in config: '$_'";
             delete $_[0]->{log_level};
         }
     }
@@ -116,7 +116,7 @@ sub initialize {
 
     # Merge with environment variables
     while ( my ( $k, $v ) = each %environment ) {
-        $config->{$v} = $ENV{$k} if $ENV{$k};
+        $config->{$v} = $ENV{$k} if defined $ENV{$k};
     }
 
     delete $config->{environments};

--- a/share/test.yml
+++ b/share/test.yml
@@ -11,3 +11,4 @@ transaction_tracer:
 environments:
     environment:
         license_key: eu01xxdeadbeefdeadbeefdeadbeefdeadbeNRAL
+        log_level: info


### PR DESCRIPTION
This makes it so that values in environment variables override the config read during initialisation.

A similar change was added in 7717f4737bce6ee7550962fcbc0d5744387e0690 but that only applied to the config that was read via `local_config`. With this change, the same behaviour applies to the config read via `global_config`.