### PR TITLE
Support setting daemon timeout in configuration file

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ Revision history for NewFangle::Agent
       the global config if they were truthy. This has been changed so they
       are read if they are defined. This is similar to the issue fixed in
       0.007.
+    * Added a new `daemon_timeout` field to the configuration file to specify
+      how many seconds a connection to the daemon should wait before aborting.
+      This setting is respected by the `run-perl` command in newrelic-admin.
 
 0.009     2022-08-22 15:46:53 BST
 

--- a/bin/newrelic-admin
+++ b/bin/newrelic-admin
@@ -53,14 +53,18 @@ Executes the Perl interpreter with the supplied arguments but forces
 the initialisation of the agent and wraps the command in a transaction.
 
 If using an agent configuration file, the path to the file should be
-supplied by the environment variable NEWRELIC_CONFIG_FILE. Alternatively,
-just the licence key, application and log file details can be supplied via
-environment variables NEWRELIC_LICENSE_KEY, NEWRELIC_APP_NAME and
-NEWRELIC_LOG_FILE.
+supplied by the environment variable NEWRELIC_CONFIG_FILE. Any other
+environment variables that affect the configuration of the agent will
+apply. For more details, see the documentation for the
+NewFangle::Agent::Config module or the details in the sample
+configuration file created via the 'generate-config` command.
 
-NewRelic is initialised for the host specified in NEWRELIC_DAEMON_HOST
-The transaction name specified is initiated for the App specified in
-NEWRELIC_APP_NAME
+NewRelic is initialised for the host specified in the active configuration
+or in the NEWRELIC_DAEMON_HOST environment variable.
+
+The provided command will run inside a transaction. The name of the
+transaction will be taken from the value of the '--tx' option, or default
+to 'newrelic-admin' if none is provided.
 USAGE
         return;
     }
@@ -85,9 +89,17 @@ USAGE
         @{ $struct->to_perl }{qw( log_filename log_level )}
     );
 
-    NewFangle::newrelic_init( $config->{daemon_host}, 100 );
+    NewFangle::newrelic_init(
+        $config->{daemon_host},
+        $config->{daemon_timeout} * 1_000,
+    );
 
-    my $app = eval { NewFangle::App->new( $struct, 100 ) };
+    my $app = eval {
+        NewFangle::App->new(
+            $struct,
+            $config->{daemon_timeout} * 1_000,
+        )
+    };
 
     local $NewFangle::Agent::TX;
     $NewFangle::Agent::TX = $app->start_non_web_transaction($txn)

--- a/lib/NewFangle/Agent/Config.pm
+++ b/lib/NewFangle/Agent/Config.pm
@@ -19,9 +19,10 @@ our $VERSION = '0.010';
 my ( $config );
 
 my $defaults = {
-    enabled      => 0,
-    log_filename => 'stderr',
-    log_level    => 'error',
+    enabled        => 0,
+    log_filename   => 'stderr',
+    log_level      => 'error',
+    daemon_timeout => 0.1,
     distributed_tracing => {
         enabled => 0,
     },
@@ -57,12 +58,13 @@ my $defaults = {
 };
 
 my %environment = (
-    NEWRELIC_APP_NAME    => 'app_name',
-    NEWRELIC_LICENSE_KEY => 'license_key',
-    NEWRELIC_LOG_FILE    => 'log_filename',
-    NEWRELIC_LOG_LEVEL   => 'log_level',
-    NEWRELIC_ENABLED     => 'enabled',
-    NEWRELIC_DAEMON_HOST => 'daemon_host',
+    NEWRELIC_APP_NAME       => 'app_name',
+    NEWRELIC_LICENSE_KEY    => 'license_key',
+    NEWRELIC_LOG_FILE       => 'log_filename',
+    NEWRELIC_LOG_LEVEL      => 'log_level',
+    NEWRELIC_ENABLED        => 'enabled',
+    NEWRELIC_DAEMON_HOST    => 'daemon_host',
+    NEWRELIC_DAEMON_TIMEOUT => 'daemon_timeout',
 );
 
 my $set_log = sub {
@@ -164,15 +166,13 @@ sub struct {
         $tx->{datastore_reporting}{threshold_us} = $seconds * 1_000_000;
     }
 
-    delete $agent->{enabled};
-    delete $agent->{daemon_host};
+    delete @{$agent}{qw( enabled daemon_host daemon_timeout )};
 
     # C Struct log levels are narrower
     $agent->{log_level} = 'error' if $agent->{log_level} eq 'critical';
     $agent->{log_level} = 'debug' if $agent->{log_level} eq 'trace';
 
-    delete $tx->{include};
-    delete $tx->{exclude};
+    delete @{$tx}{qw( include exclude )};
 
     # Silence warnings in FFI::CStructDef about falsy empty strings
     $agent->{datastore_tracer}{database_name_reporting}        ||= 0;

--- a/lib/NewFangle/Agent/Config.pod
+++ b/lib/NewFangle/Agent/Config.pod
@@ -56,6 +56,7 @@ These are the hard-coded default values, used if nothing else is provided:
     enabled: false
     log_filename: stderr
     log_level: error
+    daemon_timeout: 0.1
 
     distributed_tracing:
         enabled: true
@@ -145,6 +146,10 @@ Mapped to L<enabled|/enabled>.
 =head4 NEWRELIC_DAEMON_HOST
 
 Mapped to L<daemon_host|/daemon_host>.
+
+=head4 NEWRELIC_DAEMON_TIMEOUT
+
+Mapped to L<daemon_timeout|/daemon_timeout>.
 
 =head4 NEWRELIC_CONFIG_FILE
 
@@ -266,6 +271,13 @@ L<the documentation|https://docs.newrelic.com/docs/agents/c-sdk/get-started/intr
 for more details.
 
 Can be overridden with the C<NEWRELIC_DAEMON_HOST> environment file.
+
+=head2 daemon_timeout
+
+Set the number of seconds a connection to the New Relic daemon should wait
+before it times out.
+
+Can be overridden with the C<NEWRELIC_DAEMON_TIMEOUT> environment file.
 
 =head2 distributed_tracing
 

--- a/share/newrelic.yml
+++ b/share/newrelic.yml
@@ -23,17 +23,23 @@
 # application and reports this data to the New Relic UI at
 # newrelic.com. This global switch is normally overridden for
 # each environment below.
+# This can be overriden with the NEWRELIC_ENABLED environment
+# variable.
 enabled: true
 
 # You must specify the license key associated with your New
 # Relic account. This key binds the Perl Agent's data to your
 # account in the New Relic service.
+# This can be overriden with the NEWRELIC_LICENSE_KEY environment
+# variable.
 license_key: '*** REPLACE ME ***'
 
 # The application name. Set this to be the name of your
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
 # entry on your home dashboard page.
+# This can be overriden with the NEWRELIC_APP_NAME environment
+# variable.
 app_name: Perl Application
 
 # Sets the name of a file to log agent messages to. Whatever you
@@ -44,6 +50,8 @@ app_name: Perl Application
 # possible to say "stderr" and output to standard error output.
 # This would normally result in output appearing in your web
 # server log.
+# This can be overriden with the NEWRELIC_LOG_FILE environment
+# variable.
 log_filename: stdout
 
 # Sets the level of detail of messages sent to the log file, if
@@ -55,12 +63,22 @@ log_filename: stdout
 # of information very quickly, so it is best not to keep the
 # agent at this level for longer than it takes to reproduce the
 # problem you are experiencing.
+# This can be overriden with the NEWRELIC_LOG_LEVEL environment
+# variable.
 log_level: info
 
 # Set to the host and port number of the New Relic C daemon
 # See https://docs.newrelic.com/docs/agents/c-sdk/get-started/introduction-c-sdk/#architecture
 # for more details.
+# This can be overriden with the NEWRELIC_DAEMON_HOST environment
+# variable.
 # daemon_host: ...
+
+# Set the number of seconds a connection to the daemon should wait
+# before timing out.
+# This can be overriden with the NEWRELIC_DAEMON_TIMEOUT environment
+# variable.
+daemon_timeout: 0.1
 
 # Distributed tracing lets you see the path that a request takes
 # through your distributed system. Enabling distributed tracing
@@ -114,6 +132,9 @@ transaction_tracer:
 # specific environment will be used when the environment argument to the
 # newrelic.agent.initialize() function has been defined to be either
 # "development", "test", "staging" or "production".
+#
+# The active environment can be set with the NEWRELIC_ENVIRONMENT
+# environment variable.
 #
 
 environments:

--- a/share/test.yml
+++ b/share/test.yml
@@ -4,6 +4,7 @@ app_name: Perl Application
 log_level: error
 transaction_tracer:
     enabled: true
+    duration: 0.05
     include:
         paths:
             - t/lib

--- a/t/config.t
+++ b/t/config.t
@@ -48,6 +48,9 @@ subtest 'New Relic environment override' => sub {
             license_key      => 'eu01xxdeadbeefdeadbeefdeadbeefdeadbeNRAL',
             log_level        => 'info',
             log_filename     => 'stderr',
+            transaction_tracer => {
+                duration_us => 50_000,
+            },
             datastore_tracer => {
                 database_name_reporting => 0,
                 instance_reporting      => 0,


### PR DESCRIPTION
Adds a `daemon_timeout` field to the configuration file to limit the amount of time a connection to the daemon should wait before timing out.